### PR TITLE
[changed] min and max length for S3 bucket name

### DIFF
--- a/lambada-maven-plugin/aws/resources.json
+++ b/lambada-maven-plugin/aws/resources.json
@@ -15,8 +15,8 @@
     "DeploymentS3Bucket": {
       "Description": "Deployment S3 Bucket is where project is deployed after mvn deploy command.",
       "Type": "String",
-      "MinLength": "1",
-      "MaxLength": "25"
+      "MinLength": "3",
+      "MaxLength": "63"
     },
     "DeploymentS3Key": {
       "Description": "Deployment S3 Key is the S3 Path where project is deployed after mvn deploy command.",

--- a/lambada-maven-plugin/src/main/java/org/lambadaframework/aws/Cloudformation.java
+++ b/lambada-maven-plugin/src/main/java/org/lambadaframework/aws/Cloudformation.java
@@ -29,8 +29,8 @@ public class Cloudformation extends AWSTools {
             "    \"DeploymentS3Bucket\": {\n" +
             "      \"Description\": \"Deployment S3 Bucket is where project is deployed after mvn deploy command.\",\n" +
             "      \"Type\": \"String\",\n" +
-            "      \"MinLength\": \"1\",\n" +
-            "      \"MaxLength\": \"25\"\n" +
+            "      \"MinLength\": \"3\",\n" +
+            "      \"MaxLength\": \"63\"\n" +
             "    },\n" +
             "    \"DeploymentS3Key\": {\n" +
             "      \"Description\": \"Deployment S3 Key is the S3 Path where project is deployed after mvn deploy command.\",\n" +


### PR DESCRIPTION
The current min (1) and max (25) are set incorrectly in the Cloudformation file. According to http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html

"Bucket names must be at least 3 and no more than 63 characters long."