### PR TITLE
The operator ("<>") should be used.

### DIFF
--- a/lambada-maven-plugin/src/main/java/org/lambadaframework/deployer/Deployment.java
+++ b/lambada-maven-plugin/src/main/java/org/lambadaframework/deployer/Deployment.java
@@ -125,7 +125,7 @@ public class Deployment {
     }
 
     public Collection<Parameter> getCloudFormationParameters() {
-        Collection<Parameter> parameters = new ArrayList<Parameter>();
+        Collection<Parameter> parameters = new ArrayList<>();
         for (Map.Entry<Object, Object> e : properties.entrySet()) {
             parameters.add(new Parameter().withParameterKey((String) e.getKey()).withParameterValue((String) e.getValue()));
         }

--- a/wagon/src/main/java/org/lambadaframework/wagon/SimpleStorageServiceWagon.java
+++ b/wagon/src/main/java/org/lambadaframework/wagon/SimpleStorageServiceWagon.java
@@ -117,7 +117,7 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
 
     @Override
     protected List<String> listDirectory(String directory) throws ResourceDoesNotExistException {
-        List<String> directoryContents = new ArrayList<String>();
+        List<String> directoryContents = new ArrayList<>();
 
         try {
             String prefix = getKey(directory);
@@ -201,7 +201,7 @@ public final class SimpleStorageServiceWagon extends AbstractWagon {
     }
 
     private List<String> getResourceNames(ObjectListing objectListing, Pattern pattern) {
-        List<String> resourceNames = new ArrayList<String>();
+        List<String> resourceNames = new ArrayList<>();
 
         for (String commonPrefix : objectListing.getCommonPrefixes()) {
             resourceNames.add(getResourceName(commonPrefix, pattern));

--- a/wagon/src/main/java/org/lambadaframework/wagon/StandardSessionListenerSupport.java
+++ b/wagon/src/main/java/org/lambadaframework/wagon/StandardSessionListenerSupport.java
@@ -27,7 +27,7 @@ final class StandardSessionListenerSupport implements SessionListenerSupport {
 
     private final Wagon wagon;
 
-    private final Set<SessionListener> sessionListeners = new HashSet<SessionListener>();
+    private final Set<SessionListener> sessionListeners = new HashSet<>();
 
     StandardSessionListenerSupport(Wagon wagon) {
         this.wagon = wagon;

--- a/wagon/src/main/java/org/lambadaframework/wagon/StandardTransferListenerSupport.java
+++ b/wagon/src/main/java/org/lambadaframework/wagon/StandardTransferListenerSupport.java
@@ -28,7 +28,7 @@ final class StandardTransferListenerSupport implements TransferListenerSupport {
 
     private final Wagon wagon;
 
-    private final Set<TransferListener> transferListeners = new HashSet<TransferListener>();
+    private final Set<TransferListener> transferListeners = new HashSet<>();
 
     StandardTransferListenerSupport(Wagon wagon) {
         this.wagon = wagon;

--- a/wagon/src/test/java/org/lambadaframework/wagon/SimpleStorageServiceWagonIntegrationTest.java
+++ b/wagon/src/test/java/org/lambadaframework/wagon/SimpleStorageServiceWagonIntegrationTest.java
@@ -82,7 +82,7 @@ public final class SimpleStorageServiceWagonIntegrationTest {
     }
 
     private List<String> getBuckets() {
-        List<String> buckets = new ArrayList<String>();
+        List<String> buckets = new ArrayList<>();
 
         String value = System.getProperty("buckets");
         if (value != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.