### PR TITLE
Resources should be closed

### DIFF
--- a/jax-rs-extractor/src/main/java/org/lambadaframework/jaxrs/JAXRSParser.java
+++ b/jax-rs-extractor/src/main/java/org/lambadaframework/jaxrs/JAXRSParser.java
@@ -77,7 +77,10 @@ public class JAXRSParser {
             }
 
         }
-
+        
+        jarFile.close();
+        cl.close();
+        
         return classes;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “Resources should be closed”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.