### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/logger/src/main/java/org/lambadaframework/logger/LambdaLogger.java
+++ b/logger/src/main/java/org/lambadaframework/logger/LambdaLogger.java
@@ -12,6 +12,9 @@ public class LambdaLogger {
 
     private static Level globalLogLevel = Level.ALL;
 
+    private LambdaLogger() {
+    }
+
     private static Appender getAppender() {
         if (appender == null) {
             PatternLayout patternLayout = new PatternLayout();

--- a/runtime/src/main/java/org/lambadaframework/runtime/ResourceMethodInvoker.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/ResourceMethodInvoker.java
@@ -23,6 +23,9 @@ public class ResourceMethodInvoker {
 
     static final Logger logger = LambdaLogger.getLogger(ResourceMethodInvoker.class);
 
+    private ResourceMethodInvoker() {
+    }
+
     private static Object toObject(String value, Class clazz) {
         if (Integer.class == clazz || Integer.TYPE == clazz) return Integer.parseInt(value);
         if (Long.class == clazz || Long.TYPE == clazz) return Long.parseLong(value);

--- a/runtime/src/main/java/org/lambadaframework/runtime/errorhandling/ErrorHandler.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/errorhandling/ErrorHandler.java
@@ -15,6 +15,9 @@ public class ErrorHandler {
 
     static final Logger logger = LambdaLogger.getLogger(ErrorHandler.class);
 
+    private ErrorHandler() {
+    }
+
     public static ErrorResponse getErrorResponse(Exception e) {
         try {
             throw e;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.