### PR TITLE
Better test stability. 

### DIFF
--- a/jax-rs-extractor/tests/java/org/lambadaframework/jaxrs/JAXRSParserTest.java
+++ b/jax-rs-extractor/tests/java/org/lambadaframework/jaxrs/JAXRSParserTest.java
@@ -1,28 +1,34 @@
 package org.lambadaframework.jaxrs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.List;
 
 import org.junit.Test;
 import org.lambadaframework.jaxrs.model.Resource;
 import org.lambadaframework.stubs.StubHandler;
 
-import java.util.List;
-
-import static org.junit.Assert.*;
-
-
 public class JAXRSParserTest {
 
     /**
-     * To run this test, lambada-stub-handlers module should be compiled
-     * and packaged in lambada-stub-handlers/target folder
+     * To run this test, lambada-stub-handlers module should be compiled and
+     * packaged in lambada-stub-handlers/target folder
      *
      * @throws Exception
      */
     @Test
     public void testScanJar() throws Exception {
-        JAXRSParser parser = new JAXRSParser().withJarFile(
-                "../stub-handlers/target/stub-handlers-0.0.5.jar",
-                "org.lambadaframework");
+
+        // Finds the filename of the stub-handler-jar without regards to version numbering.
+        String stubHandlerFileName = new File("../stub-handlers/target").listFiles(new FilenameFilter() {
+            public boolean accept(File dir, String filename) {
+                return filename.startsWith("stub-handlers-");
+            }
+        })[0].getAbsolutePath();
+        JAXRSParser parser = new JAXRSParser().withJarFile(stubHandlerFileName, "org.lambadaframework");
         List<Resource> resourceList = parser.scan();
         assertTrue(resourceList.size() > 0);
     }


### PR DESCRIPTION
Better test stability. Make the test independent of the version of stub-handler.