### PR TITLE
Handel Response codes as exceptions

### DIFF
--- a/runtime/src/main/java/org/lambadaframework/runtime/Handler.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/Handler.java
@@ -48,7 +48,7 @@ public class Handler
 
     @Override
     public Response handleRequest(Request request, Context context) {
-
+        Object invoke;
         try {
             logger.debug("Request started with " + request + " and " + context);
 
@@ -57,11 +57,12 @@ public class Handler
 
             logger.debug("Matching request to a resource handler.");
             ResourceMethod matchedResourceMethod = getRouter().route(request);
+            invoke = ResourceMethodInvoker.invoke(matchedResourceMethod, request, context);
 
-            logger.debug("Returning result.");
-            return Response.buildFromJAXRSResponse(ResourceMethodInvoker.invoke(matchedResourceMethod, request, context));
         } catch (Exception ex) {
             return ErrorHandler.getErrorResponse(ex);
         }
+        logger.debug("Returning result.");
+        return Response.buildFromJAXRSResponse(invoke);
     }
 }

--- a/runtime/src/main/java/org/lambadaframework/runtime/errorhandling/ErrorHandler.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/errorhandling/ErrorHandler.java
@@ -21,11 +21,14 @@ public class ErrorHandler {
         try {
             throw e;
         } catch (InvocationTargetException ex) {
-            return new BadRequestResponse();
+            throw new RuntimeException(new BadRequestResponse().getErrorMessage());
+//            return new BadRequestResponse();
         } catch (NotFoundException ex) {
-            return new NotFoundErrorResponse("Page not found");
+            throw new RuntimeException(new NotFoundErrorResponse().getErrorMessage());
+//            return new NotFoundErrorResponse("Page not found");
         } catch (Exception ex) {
-            return new ErrorResponse();
+            throw new RuntimeException(new ErrorResponse().getErrorMessage());
+//            return new ErrorResponse();
         } finally {
             logger.debug("Exception occured:", e);
         }

--- a/runtime/src/main/java/org/lambadaframework/runtime/models/error/ErrorResponse.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/models/error/ErrorResponse.java
@@ -21,7 +21,7 @@ public class ErrorResponse extends Response {
     @JsonProperty("errorMessage")
     @Override
     public String getErrorMessage() {
-        return errorMessage;
+        return this.code + " " + errorMessage;
     }
 
 }

--- a/runtime/tests/java/org/lambadaframework/runtime/HandlerTest.java
+++ b/runtime/tests/java/org/lambadaframework/runtime/HandlerTest.java
@@ -100,6 +100,19 @@ public class HandlerTest {
                     .entity(jsonEntity)
                     .build();
         }
+
+        @POST
+        @Path("{id}/error")
+        @Consumes(MediaType.APPLICATION_JSON)
+        public javax.ws.rs.core.Response createEntityWithStatus401(
+                String jsonString
+        ) {
+
+            return javax.ws.rs.core.Response
+                    .status(401)
+                    .entity(jsonString)
+                    .build();
+        }
     }
 
     private Router getMockRouter(String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
@@ -310,6 +323,38 @@ public class HandlerTest {
 
         assertEquals("201", response.getErrorMessage());
         assertEquals(1, ((NewEntityRequest) response.getEntity()).id);
+    }
+
+    @Test
+    public void testWith401ExceptionResult()
+            throws Exception {
+
+        Request exampleRequest = getRequest("{\n" +
+                "  \"package\": \"org.lambadaframework\",\n" +
+                "  \"pathTemplate\": \"/{id}/error\",\n" +
+                "  \"method\": \"POST\",\n" +
+                "  \"requestBody\": \"{}\",\n" +
+                "  \"path\": {\n" +
+                "    \"id\": \"123\"\n" +
+                "  },\n" +
+                "  \"querystring\": {\n" +
+                "        \"query1\": \"test3\",\n" +
+                "    \"query2\": \"test\"\n" +
+                "  },\n" +
+                "  \"header\": {}\n" +
+                "}");
+
+
+        Handler handler = new Handler();
+        handler.setRouter(getMockRouter("createEntityWithStatus401", String.class));
+        try {
+            handler.handleRequest(exampleRequest, getContext());
+            fail("Should have thrown an excpetion");
+        } catch(RuntimeException e) {
+            assertTrue(e.getMessage().contains("401"));
+        }
+
+
     }
 
 }


### PR DESCRIPTION
As it is now it can only return 200 responses. See Issue: #11 
For the API Gateway to return other respons codes we throw exceptions instead.
Given that the exception's message has the response code the Lambda Error RegEx will get a match and handle it as a response with the recived code.

**Drawbacks:** This solution won't return the entity body in it's repsonse when exception is thrown.

I don't think this is the a optimal solution. Maybe we should look at AWS Lambda Proxy which will make the lambadaframework less complex and probably able to handle other respons codes and return a entity body with it. 

[AWS Lambda Proxy](docs.aws.amazon.com/apigateway/latest/developerguide/integrating-api-with-aws-services-lambda.html)

