### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ All the possible parameters are as follows:
 
 Below you can find detailed information about the configuration parameters:
 
-- **packageName:** The package name to scan for JAX-RS annotations.
+- **packageName:** The package name of the parent package in which the JAX-RS annotations reside.
 
 - **regionToDeploy:** AWS Region to deploy your API. It should be a region where Lambda and API Gateway are supported.
 


### PR DESCRIPTION
In issue  #30 , it was found that the package name needs to be the parent of the package in which the annotations reside . Updated the Readme