### PR TITLE
Support for CORS and Custom Response Headers, fix #4 and #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .project
 .classpath
 .settings
+/bin/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Lambada framework is a REST framework that implements [JAX-RS](https://jax-rs-sp
 * Support for the most common JAX-RS annotations.
 * XML based configuration for Lambda function including VPC, custom execution role
 * Support for multiple stages and regions.
+* Support for CORS and Custom Response Headers (using native JAX RS Response.header())
 
 Lambada consists of a runtime module, a local simulator and finally a maven plugin to configure and deploy the whole project to API Gateway.
 

--- a/jax-rs-extractor/pom.xml
+++ b/jax-rs-extractor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.lambadaframework</groupId>
         <artifactId>lambada</artifactId>
-        <version>0.0.6</version>
+        <version>0.0.6-cors</version>
     </parent>
     <artifactId>jax-rs-extractor</artifactId>
     <packaging>jar</packaging>

--- a/lambada-maven-plugin/pom.xml
+++ b/lambada-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.lambadaframework</groupId>
         <artifactId>lambada</artifactId>
-        <version>0.0.6</version>
+        <version>0.0.6-cors</version>
     </parent>
 
     <artifactId>lambada-maven-plugin</artifactId>

--- a/lambada-maven-plugin/src/main/java/org/lambadaframework/aws/ApiGateway.java
+++ b/lambada-maven-plugin/src/main/java/org/lambadaframework/aws/ApiGateway.java
@@ -67,7 +67,12 @@ public class ApiGateway extends AWSTools {
             "}";
 
 
-    protected final String OUTPUT_TEMPLATE = "$input.json('$.entity')";
+    protected final String OUTPUT_TEMPLATE = 
+    		"$input.json('$.entity')\n" + 
+    		"#set($map = $util.parseJson($input.json('$.headers')))\n" + 
+    		"#foreach ($mapEntry in $map.entrySet())\n" + 
+    		"#set($context.responseOverride.header[\"${mapEntry.key}\"] = \"${mapEntry.value}\")\n" + 
+    		"#end\n";
 
     protected final String AUTHORIZATION_TYPE = "NONE";
     protected final String INVOCATION_METHOD = "POST";

--- a/logger/pom.xml
+++ b/logger/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lambada</artifactId>
         <groupId>org.lambadaframework</groupId>
-        <version>0.0.6</version>
+        <version>0.0.6-cors</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Log support</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.lambadaframework</groupId>
     <artifactId>lambada</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.6-cors</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.lambadaframework</groupId>
         <artifactId>lambada</artifactId>
-        <version>0.0.6</version>
+        <version>0.0.6-cors</version>
     </parent>
     <artifactId>runtime</artifactId>
     <packaging>jar</packaging>

--- a/stub-handlers/pom.xml
+++ b/stub-handlers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lambada</artifactId>
         <groupId>org.lambadaframework</groupId>
-        <version>0.0.6</version>
+        <version>0.0.6-cors</version>
     </parent>
     <name>Stub Handlers for Tests</name>
     <modelVersion>4.0.0</modelVersion>

--- a/wagon/pom.xml
+++ b/wagon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lambada</artifactId>
         <groupId>org.lambadaframework</groupId>
-        <version>0.0.6</version>
+        <version>0.0.6-cors</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>S3 Wagon</name>


### PR DESCRIPTION
All JAX-RS Response Headers including CORS and Custom Headers are now mapped by the API Gateway.